### PR TITLE
Clean up markdown typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Version: 1.4.0 "Cole"
 - Browse our Plugin Repository
 - [Contact](http://www.kiwijs.org/help/) us for more information
 
-##Welcome to Kiwi!
+## Welcome to Kiwi!
 
 Born out of a desire to democratize HTML5 game development and to make something that we love available to the masses, we bring you Kiwi.js.
 
@@ -26,7 +26,7 @@ Our mission is to follow the best open source community practices. We're backing
 
 And we do think you're going to feel the love. What couldn't you love about a game engine that is named after a fluffy adorable bird *and* one of the world's greatest game inventors?
 
-##How to Guides
+## How to Guides
 
 Have you ever been trying to figure out how to do something on a website and the help pages resemble a [Goosebumps](https://en.wikipedia.org/wiki/Goosebumps) choose your own adventure book? So have we, which is why we have spent literally hundreds of hours writing good help documents for Kiwi.js developers.
 
@@ -81,62 +81,62 @@ More details can be found on the [Kiwi.JS repo](https://github.com/gamelab/kiwi.
 ## Previous Changes
 View the [changelog](https://github.com/gamelab/kiwi.js/blob/master/CHANGELOG.md) for a list of changes from previous versions.
 
-##Features
+## Features
 
-####Powerful Rendering
+#### Powerful Rendering
 Kiwi uses a custom built WebGL rendering system for targeting modern mobile and desktop browsers as well as mobile apps through [CocoonJS](https://www.ludei.com/).
 
 Not only is Kiwi lightning quick but it is also extendible, meaning that fellow contributors can easily write their own powerful rendering Plugins and Add-ons using WebGL Shaders. For instance our WebGL Particle Plugin creates stunning special FX using this system.
 
 Of course, you can render to canvas too, which means older browsers, and mobile browsers, don't miss out.
 
-####Mobile Publishing
+#### Mobile Publishing
 Kiwi.js is closely aligned with Ludei's [CocoonJS](https://www.ludei.com/). You can use Cocoon to wrap up your game and play it on iOS or Android devices.
 
-####State Management
+#### State Management
 A state management system lets you easily move between and manage game states. Each state has an optional preloader phase, a create phase, an update loop, and a destroy phase. Each of the phases are highly configurable.
 
-####Flexible Asset Loading and Management
+#### Flexible Asset Loading and Management
 It's easy to load in images, sound and data. You can decide when you want it to load (e.g. in a single payload at the beginning, or on a per state basis). When your assets are loaded they're super easy to access from data libraries.
 
-####Gameobjects - Sprites, Images, Textfields
+#### Gameobjects - Sprites, Images, Textfields
 Gameobjects are objects that get rendered in your game. Whether they're frame-based sprites, webGL particles, static images or text fields, they all can be moved in the game world and placed in the scene graph.
 
-####Entity/Component system
+#### Entity/Component system
 Each gameobject is an "Entity" and can have "components" attached to it. Components are small pieces of code that do something useful. For instance the arcade physics system is implemented as a component. If you want your game object to use physics, simply attach a physics component to it. Some of the standard gameobjects have components such as animation already attached. You can also write your own components.
 
-####Scene Graph (Grouping objects)
+#### Scene Graph (Grouping objects)
 The scene graph represents all of the gameobjects that visible in your gameworld. You can group objects, and place groups within groups. You can animate and move your objects and groups and they'll behave in a consistent manner depending on how they are nested.
 
-####Animation
+#### Animation
 Sprites have an animation component that enables frame by animation from spritesheets and texture atlases. You can easily define frame sequences and frame lengths, play, pause, loop and reverse animations. There is also a built in tweening system.
 
-####Input (Including Touch)
+#### Input (Including Touch)
 Kiwi.js supports input for mouse, keyboard and of course touch. Mouse and touch events are easily handled by Kiwi.js pointer objects, so in most cases you don't have to worry about where the input is coming from.
 
-####Camera
+#### Camera
 Your game world is viewed through a controllable camera, which you can move and spin.
 
-####Tilemaps
+#### Tilemaps
 Kiwi.js has support for tilemaps, including multiple tile layers. The Tiled map data format is supported, including isometric tiles. You can programatically generate tile maps, and once a tile map is created you can easily manipulate the data to change the tilemap dynamically.
 
-####Audio
+#### Audio
 Kiwi.js supports the WebAudio api, and falls back to using `<audio>` tag when it is not available. Audio sprites are also supported, unless of course your device happens to be some weird futuristic ghetto blaster.
 
-####Monetization
+#### Monetization
 As fellow game developers we know what it is like to be hungry, shivering on the corner holding a can of change in one hand and a damp "will code for cash" cardboard sign in the other.
 
 Because of this, creating an In-App Purchasing Plugin to allow you to monetize your games was a top priority and is available now.
 
 [CocoonJS](https://www.ludei.com/) users can easily add a virtual currency to consumable goods via the AppStore.
 
-####Plugin System
+#### Plugin System
 As part of our dedication to open source principles, the plugin system lets developers extend many aspects of Kiwi.js. The rules around creating them are unobtrusive, making plugins easy to create and attach. Plugins will soon be able to be sold in the upcoming Kiwi.js marketplace.
 
-####Integration with powerful tools
+#### Integration with powerful tools
 Kiwi.js is part of a larger ecosystem of products which will enable you to create games and game content using specialised tools such as the Gamefroot cloud based game building solution. [Because you can never get enough power](https://www.youtube.com/watch?v=YQwYNca4iog)
 
-##Getting Started
+## Getting Started
 
 ![Splash](http://kiwi-js.s3.amazonaws.com/html5-conference-game.png)
 
@@ -153,7 +153,7 @@ Choose from any of the following:
 
 There will be an ever increasing library of free and premium blueprints to get you started.
 
-##Starting from scratch
+## Starting from scratch
 
 The easiest way to start with a blank game is to take a copy of the `/gameTemplate` folder. This contains a recommended folder structure and all default files already in place.
 
@@ -161,17 +161,17 @@ You will need to use a web server to open the index file. We suggest XAMPP, WAMP
 
 A more advanced, but still simple, way to create a blank game is to use the [Kiwi.js Yeoman Generator](https://github.com/gamelab/generator-kiwigame). This will create build files and other goodies for you as well.
 
-###Viewing the examples
+### Viewing the examples
 
 We have a throng of examples. So many, in fact, that one kiwi got tired carrying them all. As generous souls, we put them in their own repo. Check out the [examples repo](https://github.com/gamelab/examples) and look in `tutorials/core`.
 
 Also, don't forget to check out the [examples site](http://examples.kiwijs.org/) where we demo all the library features and the cool plugins available to you.
 
-###What's in this repo?
+### What's in this repo?
 
 Note: If you just want to use the framework, the kiwi.js and kiwi.min.js files are located in the `/build` folder, and the docs in the `/docs` folder, and there is a template game in the `/templateGame` folder. You probably don't need to worry about the rest of the repo!
 
-###Folders
+### Folders
 
 * build - The kiwi.js and kiwi.min.js files
 * src - The kiwi.js framework source code
@@ -179,7 +179,7 @@ Note: If you just want to use the framework, the kiwi.js and kiwi.min.js files a
 * docstyles - Used to store assets for building docs.
 * templateGame - An example TemplateGame to help you on your way to developing a Kiwi.JS game.
 
-###Files
+### Files
 
 * .gitignore - mask files from git
 * bower.json - see below about bower installation
@@ -191,16 +191,16 @@ Note: If you just want to use the framework, the kiwi.js and kiwi.min.js files a
 
 ![Splash](http://html5experts.jp/wp-content/uploads/2013/11/image05.png)
 
-##Getting and building the library
+## Getting and building the library
 
-###Bower
+### Bower
 If you use the [Bower](http://bower.io/) package manager you can install kiwi.js with
 
 ```
 bower install kiwijs
 ```
 
-###Yeoman
+### Yeoman
 If you use the [Yeoman](https://github.com/gamelab/generator-kiwigame) scaffolding system you can install a blank kiwi.js game with
 
 ```
@@ -231,7 +231,7 @@ grunt docs
 The csproj and grunt compilation methods both output a single kiwi.js file in `/build`
 Grunt will also create a min.js version and also output a kiwi.d.ts definition file in `/build` as well
 
-###Using Visual Studio
+### Using Visual Studio
 
 * Requires Microsoft Visual Studio 2013 or later.
 * Install the TypeScript plugin.
@@ -240,7 +240,7 @@ There are csproj files for the main project.
 
 We advise that you build using Grunt, as this will correctly concatenate certain additional files.
 
-##Extending Kiwi.js
+## Extending Kiwi.js
 
 You want Plugins? [We got Plugins!](http://www.kiwijs.org/documentation/kiwi-js-plugin-tutorials/).
 
@@ -259,7 +259,7 @@ Kiwi.js is built in such a way that your plugins can do very simple or very powe
 
 To learn about building Plugins view the tutorials on [kiwijs.org](http://www.kiwijs.org/documentation/tutorials/what-are-plugins-in-kiwi-js/). You can also get started with Plugins using the Kiwi.js [Yeoman Plugin Generator](https://github.com/gamelab/generator-kiwiplugin).
 
-##Tools
+## Tools
 
 ### Visual Game Maker
 Gamefroot is the worlds most powerful and easy to use browser-based game editor.
@@ -268,7 +268,7 @@ We've partnered with [Gamefroot](http://gamefroot.com/leveleditor) and we're ple
 
 Stay tuned for more updates and more tools!
 
-##Roadmap
+## Roadmap
 
 Here are some of the features planned for future releases.
 
@@ -276,7 +276,7 @@ Here are some of the features planned for future releases.
 - Multiple cameras with filters
 - A whole new world!
 
-##Contributing
+## Contributing
 
 We'd love for you to get involved and help make Kiwi.js the best damn game framework in the world! If you'd like to contribute please get in touch, fork/clone the repo and have a dig around.
 
@@ -285,13 +285,13 @@ We'd love for you to get involved and help make Kiwi.js the best damn game frame
 - If you have a pull request for Kiwi, please only do so against the dev branch and not against the master branch.
 - Before submitting a Pull Request please run your code through JSHint to check for stylistic or formatting errors.
 
-##Bugs?
+## Bugs?
 
 If you discover a bug and find yourself wanting to jump in and help make the world of HTML5 gaming a better, less buggy, place, please add said bug to our issues tracker with as much information as possible, especially source code demonstrating the issue.
 
 https://github.com/gamelab/kiwi.js/issues/new
 
-##Community
+## Community
 
 A massive shoutout to our contributors on Github!
 
@@ -317,6 +317,6 @@ A massive shoutout to our contributors on Github!
 
 *Kiwi.js also uses code from a number of open source projects. Effort has been made to clearly identify authors in the code comments. If you notice and missing or incorrect attribution please let us know.*
 
-##License
+## License
 
 * MIT (see `license.txt` for details)


### PR DESCRIPTION
The heading tags in Markdown (`#`, `##`, `###`, ...) were used incorrectly in several places.