### PR TITLE
update() hold reference to member

### DIFF
--- a/src/core/Group.ts
+++ b/src/core/Group.ts
@@ -1064,12 +1064,13 @@ module Kiwi {
 			if (this.members.length > 0) {
 
 				for (var i = 0; i < this.members.length; i++) {
-					if (this.members[i].active === true) {
-						this.members[i].update();
+					let member = this.members[i];
+					if (member.active === true) {
+						member.update();
 					} 
 
-					if(this.members[i].exists === false) {
-						this.members[i].destroy( true );
+					if(member.exists === false) {
+						member.destroy( true );
 					}
 				}
 				


### PR DESCRIPTION
Hold reference to member in members array while acting on it. This avoids a buggy corner-case where `members[i].update()` could change the number of members in this Group, resulting in the `members[i].exists` check referencing a different member (and possibly crashing on `members[i]` being undefined).